### PR TITLE
Use only DOMContentLoaded  instead of "ready" from jQuery

### DIFF
--- a/src/sphinxjp/themes/gopher/templates/gopher/static/js/initialize.js
+++ b/src/sphinxjp/themes/gopher/templates/gopher/static/js/initialize.js
@@ -1,4 +1,4 @@
-$(document).ready(function(){
+function initializeDOM() {
   $("body > div.section").each(function(i, e){
     var target = null;
     var addElements = [];
@@ -22,4 +22,9 @@ $(document).ready(function(){
      }
      $("a.headerlink").hide();
   });
-});
+}
+if (window['_DCL']) {
+  initializeDOM();
+} else {
+  document.addEventListener('DOMContentLoaded', initializeDOM, false);
+}


### PR DESCRIPTION
After Sphinx 1.5.0, Bundled jQuery is version 3.x.x (older is 1.11.0)

So, "ready" (jQuery) will be fired after DOMContentLoaded.
This patch is to register initialize section to DOMContentLoaded.
Event listener run handlers in order of registration, so initialize is done first.